### PR TITLE
Add manifest.json for ScamSentinel

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,32 @@
+{
+  "manifest_version": 3,
+  "name": "ScamSentinel - URL Threat Detection",
+  "version": "1.0.0",
+  "description": "Advanced AI-powered URL threat detection and analysis",
+  "permissions": [
+    "activeTab",
+    "contextMenus",
+    "storage",
+    "notifications"
+  ],
+  "host_permissions": [
+    "https://wqczlzljkfdaoloujyka.supabase.co/*"
+  ],
+  "background": {
+    "service_worker": "background/service-worker.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content/content-script.js"]
+    }
+  ],
+  "action": {
+    "default_popup": "popup/popup.html",
+    "default_icon": {
+      "16": "icons/icon16.png",
+      "48": "icons/icon48.png",
+      "128": "icons/icon128.png"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- define extension manifest for ScamSentinel - URL Threat Detection

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ed71cde4c832385537c3bbb79d171