### PR TITLE
Improve service worker with Supabase auth

### DIFF
--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -1,7 +1,7 @@
 importScripts('https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm');
 
 const SUPABASE_URL = 'https://wqczlzljkfdaoloujyka.supabase.co';
-const SUPABASE_ANON_KEY = 'YOUR_SUPABASE_ANON_KEY';
+const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6IndxY3psemxqa2ZkYW9sb3VqeWthIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTMwNzY0MzgsImV4cCI6MjA2ODY1MjQzOH0.RhU05RsDNUH_uv6oJ3LIYD8hoMDCyO7MJqiwEpTdWYU';
 const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 
 function saveSession(session) {

--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -1,1 +1,59 @@
-        1 file(s) copied.
+importScripts('https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm');
+
+const SUPABASE_URL = 'https://wqczlzljkfdaoloujyka.supabase.co';
+const SUPABASE_ANON_KEY = 'YOUR_SUPABASE_ANON_KEY';
+const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+function saveSession(session) {
+  chrome.storage.local.set({ supabaseSession: session });
+}
+
+function loadSession(callback) {
+  chrome.storage.local.get(['supabaseSession'], (result) => {
+    callback(result.supabaseSession || null);
+  });
+}
+
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  if (request.action === 'login') {
+    supabase.auth.signInWithPassword({
+      email: request.email,
+      password: request.password
+    }).then(({ data, error }) => {
+      if (error) {
+        sendResponse({ status: 'error', message: error.message });
+        return;
+      }
+      saveSession(data.session);
+      sendResponse({ status: 'success', session: data.session });
+    });
+    return true;
+  }
+
+  if (request.action === 'logout') {
+    supabase.auth.signOut().then(() => {
+      chrome.storage.local.remove('supabaseSession', () => {
+        sendResponse({ status: 'success' });
+      });
+    });
+    return true;
+  }
+
+  if (request.action === 'scanURL') {
+    loadSession((session) => {
+      const token = session ? session.access_token : request.apiKey;
+      fetch(`${SUPABASE_URL}/functions/v1/secure-scan`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': token ? `Bearer ${token}` : undefined
+        },
+        body: JSON.stringify({ url: request.url })
+      })
+        .then((response) => response.json())
+        .then((data) => sendResponse({ status: 'success', result: data }))
+        .catch((error) => sendResponse({ status: 'error', message: error.message }));
+    });
+    return true;
+  }
+});


### PR DESCRIPTION
## Summary
- implement Supabase client setup in the background service worker
- support login/logout with session saved in `chrome.storage`
- fetch Supabase edge function using stored session token or API key

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687eed28157c8323841e8c82477c11a0